### PR TITLE
Add tests using testthat library

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,3 +10,4 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1
+Suggests: testthat

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -2,12 +2,3 @@ library(testthat)
 library(abbrevr)
 
 test_check("abbrevr")
-
-test_that("Correct abbreviation for 'easy' English-language titles", {
-  expect_equal(AbbrevTitle("Science"), "Science")
-  expect_equal(AbbrevTitle("Journal of Ecology"), "J. Ecol.")
-  expect_equal(AbbrevTitle("Journal of Evolutionary Biology"), "J. Evol. Biol.")
-  expect_equal(AbbrevTitle("American Journal of Epidemiology"), "Am. J. Epidemiol.")
-  expect_equal(AbbrevTitle("Annual Review of Ecology and Systematics"), "Annu. Rev. Ecol. Syst.")
-  expect_equal(AbbrevTitle("PLoS ONE"), "PLoS ONE")
-})

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,13 @@
+library(testthat)
+library(abbrevr)
+
+test_check("abbrevr")
+
+test_that("Correct abbreviation for 'easy' English-language titles", {
+  expect_equal(AbbrevTitle("Science"), "Science")
+  expect_equal(AbbrevTitle("Journal of Ecology"), "J. Ecol.")
+  expect_equal(AbbrevTitle("Journal of Evolutionary Biology"), "J. Evol. Biol.")
+  expect_equal(AbbrevTitle("American Journal of Epidemiology"), "Am. J. Epidemiol.")
+  expect_equal(AbbrevTitle("Annual Review of Ecology and Systematics"), "Annu. Rev. Ecol. Syst.")
+  expect_equal(AbbrevTitle("PLoS ONE"), "PLoS ONE")
+})

--- a/tests/testthat/test-abbrevtitle.R
+++ b/tests/testthat/test-abbrevtitle.R
@@ -1,0 +1,13 @@
+library(testthat)
+library(abbrevr)
+
+context("Title abbreviations")
+
+test_that("Correct abbreviation for easy English-language titles", {
+  expect_equal(AbbrevTitle("Science"), "Science")
+  expect_equal(AbbrevTitle("Journal of Ecology"), "J. Ecol.")
+  expect_equal(AbbrevTitle("Journal of Evolutionary Biology"), "J. Evol. Biol.")
+  expect_equal(AbbrevTitle("American Journal of Epidemiology"), "Am. J. Epidemiol.")
+  expect_equal(AbbrevTitle("Annual Review of Ecology and Systematics"), "Annu. Rev. Ecol. Syst.")
+  expect_equal(AbbrevTitle("PLoS ONE"), "PLoS ONE")
+})


### PR DESCRIPTION
Add a few simple tests of the `AbbrevTitle` function using `testthat` library